### PR TITLE
Move Jest to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "jest": "^23.1.0",
     "lz-string": "^1.4.4",
     "query-string": "^6.0.0",
     "unist-util-map": "^1.0.3"
@@ -30,6 +29,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "cross-env": "^5.1.4",
+    "jest": "^23.1.0",
     "prettier": "^1.12.1",
     "remark": "^9.0.0",
     "standard-version": "^4.3.0"


### PR DESCRIPTION
Otherwise this old version of Jest will get installed with this package and cause npm security alerts with the `jest-cli` > `yargs` > `os-locale` > `mem` dependency.