### PR TITLE
Allow recursive folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ This is than passed to the (awesome) [define api](https://codesandbox.io/docs/im
           // Customise the embedding iframe given the generated url
           // default:
           getIframe: url => `<iframe src="${url}" class="embedded-codesandbox" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`
+          
+          
+          // Customise the ignored file / folder names
+          // default:
+          ignoredFiles: [
+            'node_modules',
+            'yarn.lock',
+            'package-lock.json'
+          ]
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "gatsby-remark-embedded-codesandbox",
-  "version": "1.2.0",
-  "description": "Gatsby Remark plugin for embedding Codesandbox given a folder of files",
+  "name": "@guy/gatsby-remark-embedded-codesandbox",
+  "version": "1.0.0",
+  "description": "Gatsby Remark plugin for embedding Codesandbox given a recursive folder of files",
   "main": "index.js",
-  "repository": "https://github.com/elboman/gatsby-remark-embedded-codesandbox",
+  "repository": "https://github.com/guyathomas/gatsby-remark-embedded-codesandbox",
   "author": "Marco Botto <marco.botto@gmail.com>",
   "bugs": {
-    "url": "https://github.com/elboman/gatsby-remark-embedded-codesandbox/issues"
+    "url": "https://github.com/guyathomas/gatsby-remark-embedded-codesandbox/issues"
   },
   "keywords": [
     "gatsby",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -3,6 +3,9 @@ jest.mock(`fs`, () => {
     existsSync: jest.fn(),
     readdirSync: jest.fn(),
     readFileSync: jest.fn(),
+    statSync: jest.fn(() => ({
+      isDirectory: jest.fn(() => false)
+    }))
   };
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,16 @@ const compress = string =>
     .replace(/\//g, `_`) // Convert '/' to '_'
     .replace(/=+$/, ``); // Remove ending '='
 
+const getAllFiles = dirPath =>
+  fs.readdirSync(dirPath).reduce((acc, file) => {
+    const relativePath = dirPath + '/' + file;
+    const isDirectory = fs.statSync(relativePath).isDirectory();
+    // Removes the dirPath from start of the string
+    const fileNameForSandbox = relativePath.replace(new RegExp(`^${dirPath}/`), "")
+    const additions = isDirectory ? getAllFiles(relativePath) : [fileNameForSandbox];
+    return [...acc, ...additions];
+  }, []);
+
 module.exports = (
   { markdownAST },
   {
@@ -46,16 +56,16 @@ module.exports = (
 
   const getFilesList = directory => {
     let packageJsonFound = false;
-    const folderFiles = fs.readdirSync(directory);
+    const folderFiles = getAllFiles(directory);
     const sandboxFiles = folderFiles
       // we ignore the package.json file as it will
       // be handled separately
-      .filter(file => file !== 'package.json')
-      .map(file => {
-        const fullFilePath = path.resolve(directory, file);
+      .filter(file => !file.includes('package.json'))
+      .map(relativePath => {
+        const fullFilePath = path.resolve(__dirname, directory, relativePath);
         const content = fs.readFileSync(fullFilePath, 'utf-8');
         return {
-          name: file,
+          name: relativePath,
           content,
         };
       });
@@ -92,14 +102,13 @@ module.exports = (
   };
 
   const getPackageJsonFile = fileList => {
-    const found = fileList.filter(name => name === 'package.json');
-    return found.length > null;
+    return fileList.find(file => file.includes('package.json'));
   };
 
   const createParams = files => {
     const filesObj = files.reduce((prev, current) => {
       // parse package.json first
-      if (current.name === 'package.json') {
+      if (current.name.includes('package.json')) {
         prev[current.name] = { content: JSON.parse(current.content) };
       } else {
         prev[current.name] = { content: current.content };
@@ -109,7 +118,6 @@ module.exports = (
     const params = {
       files: filesObj,
     };
-
     return compress(JSON.stringify(params));
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,7 @@ const getAllFiles = dirPath =>
     if (file === 'node_modules') return acc;
     const relativePath = dirPath + '/' + file;
     const isDirectory = fs.statSync(relativePath).isDirectory();
-    // Removes the dirPath from start of the string
-    const fileNameForSandbox = relativePath.replace(new RegExp(`^${dirPath}/`), "")
-    const additions = isDirectory ? getAllFiles(relativePath) : [fileNameForSandbox];
+    const additions = isDirectory ? getAllFiles(relativePath) : [relativePath];
     return [...acc, ...additions];
   }, []);
 
@@ -58,7 +56,9 @@ module.exports = (
   const getFilesList = directory => {
     let packageJsonFound = false;
     const folderFiles = getAllFiles(directory);
+    const basePathRE = new RegExp(`^${directory}/`);
     const sandboxFiles = folderFiles
+      .map(file => file.replace(basePathRE, ''))
       // we ignore the package.json file as it will
       // be handled separately
       .filter(file => !file.includes('package.json'))

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const compress = string =>
 
 const getAllFiles = dirPath =>
   fs.readdirSync(dirPath).reduce((acc, file) => {
+    if (file === 'node_modules') return acc;
     const relativePath = dirPath + '/' + file;
     const isDirectory = fs.statSync(relativePath).isDirectory();
     // Removes the dirPath from start of the string


### PR DESCRIPTION
## Problem
The current plugin only supports a flat list of files, i.e.

```
App.tsx
index.ts
styles.css
Clock // Will break on build here
- Clock.tsx
```

## Solution
This PR introduces `getAllFiles` to traverse the filesystem recursively, and build up the relative path filename for the nested files.
Note: Also adds in `ignoredFiles` as part of the options, since in my testing it'd often include things like `yarn.lock` which would actually mean the generated URL was too long to be supported by codesandbox.